### PR TITLE
Tweaks to ado_workitems_to_github_issues.ps1

### DIFF
--- a/ado_workitems_to_github_issues.ps1
+++ b/ado_workitems_to_github_issues.ps1
@@ -23,11 +23,7 @@
 #   a. Original work item url 
 #   b. Basic details in a collapsed markdown table
 #   c. Entire work item as JSON in a collapsed section
-#
-
-# 
-# To Do:
-# 1. Create a comment on the Azure DevOps work item that says "Migrated to GitHub Issue #"
+# 7. Creates tag "copied-to-github" and a comment on the ADO work item. The tag prevents duplicate copying.
 #
 
 #
@@ -49,20 +45,27 @@ param (
     [bool]$gh_add_ado_comments = $false # try to get ado comments
 )
 
-echo "$ado_pat" | az devops login --organization "https://dev.azure.com/$ado_org"
-az devops configure --defaults organization="https://dev.azure.com/$ado_org" project="$ado_project"
-echo $gh_pat | gh auth login --with-token
+# Set the auth token for az commands
+$env:AZURE_DEVOPS_EXT_PAT = $ado_pat;
+# Set the auth token for gh commands
+$env:GH_TOKEN = $gh_pat;
 
-$wiql="select [ID], [Title] from workitems where [System.AreaPath] UNDER '$ado_area_path' order by [ID]"
+az devops configure --defaults organization="https://dev.azure.com/$ado_org" project="$ado_project"
+
+$wiql = "select [ID], [Title], [System.Tags] from workitems where [State] <> 'Done' and [State] <> 'Closed' and [State] <> 'Resolved' and [State] <> 'Removed' and [System.AreaPath] UNDER '$ado_area_path' and [System.Title] Contains 'CodeQL' and not [System.Tags] Contains 'copied-to-github' order by [ID]";
 
 $query=az boards query --wiql $wiql | ConvertFrom-Json
 
 Remove-Item -Path ./temp_comment_body.txt -ErrorAction SilentlyContinue
 Remove-Item -Path ./temp_issue_body.txt -ErrorAction SilentlyContinue
+$count = 0;
 
 ForEach($workitem in $query) {
     $original_workitem_json_beginning="`n`n<details><summary>Original Work Item JSON</summary><p>" + "`n`n" + '```json'
     $original_workitem_json_end="`n" + '```' + "`n</p></details>"
+
+    $workitemId = $workitem.id;
+    $workitemTags = $workitem.fields.'System.Tags';
 
     $details_json = az boards work-item show --id $workitem.id --output json
     $details = $details_json | ConvertFrom-Json
@@ -71,12 +74,16 @@ ForEach($workitem in $query) {
     # workaround for https://github.com/cli/cli/issues/3425 and https://stackoverflow.com/questions/6714165/powershell-stripping-double-quotes-from-command-line-arguments
     $title = $details.fields.{System.Title} -replace "`"","`\`""
 
+    Write-Host "Copying work item $workitemId to $gh_org/$gh_repo on github";
+
     $description=""
 
     # bug doesn't have Description field - add repro steps and/or system info
     if ($details.fields.{System.WorkItemType} -eq "Bug") {
         if(![string]::IsNullOrEmpty($details.fields.{Microsoft.VSTS.TCM.ReproSteps})) {
-            $description+="## Repro Steps`n`n" + $details.fields.{Microsoft.VSTS.TCM.ReproSteps} + "`n`n"
+            # Fix line # reference in "Repository:" URL.
+            $reproSteps = ($details.fields.{Microsoft.VSTS.TCM.ReproSteps}).Replace('/tree/', '/blob/').Replace('?&amp;path=', '').Replace('&amp;line=', '#L');
+            $description += "## Repro Steps`n`n" + $reproSteps + "`n`n";
         }
         if(![string]::IsNullOrEmpty($details.fields.{Microsoft.VSTS.TCM.SystemInfo})) {
             $description+="## System Info`n`n" + $details.fields.{Microsoft.VSTS.TCM.SystemInfo} + "`n`n"
@@ -89,10 +96,10 @@ ForEach($workitem in $query) {
         }
     }
 
-    $description | Out-File -FilePath ./temp_issue_body.txt
+    $description | Out-File -FilePath ./temp_issue_body.txt -Encoding ASCII;
 
     $url="[Original Work Item URL](https://dev.azure.com/$ado_org/$ado_project/_workitems/edit/$($workitem.id))"
-    $url | Out-File -FilePath ./temp_comment_body.txt
+    $url | Out-File -FilePath ./temp_comment_body.txt -Encoding ASCII;
 
     # use empty string if there is no user is assigned
     if ( $null -ne $details.fields.{System.AssignedTo}.displayName )
@@ -107,17 +114,17 @@ ForEach($workitem in $query) {
     
     # create the details table
     $ado_details_beginning="`n`n<details><summary>Original Work Item Details</summary><p>" + "`n`n"
-    $ado_details_beginning | Add-Content -Path ./temp_comment_body.txt
+    $ado_details_beginning | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
     $ado_details= "| Created date | Created by | Changed date | Changed By | Assigned To | State | Type | Area Path | Iteration Path|`n|---|---|---|---|---|---|---|---|---|`n"
     $ado_details+="| $($details.fields.{System.CreatedDate}) | $($details.fields.{System.CreatedBy}.displayName) | $($details.fields.{System.ChangedDate}) | $($details.fields.{System.ChangedBy}.displayName) | $ado_assigned_to_display_name | $($details.fields.{System.State}) | $($details.fields.{System.WorkItemType}) | $($details.fields.{System.AreaPath}) | $($details.fields.{System.IterationPath}) |`n`n"
-    $ado_details | Add-Content -Path ./temp_comment_body.txt
+    $ado_details | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
     $ado_details_end="`n" + "`n</p></details>"    
-    $ado_details_end | Add-Content -Path ./temp_comment_body.txt
+    $ado_details_end | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
 
     # prepare the comment
-    $original_workitem_json_beginning | Add-Content -Path ./temp_comment_body.txt
-    $details_json | Add-Content -Path ./temp_comment_body.txt
-    $original_workitem_json_end | Add-Content -Path ./temp_comment_body.txt
+    $original_workitem_json_beginning | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
+    $details_json | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
+    $original_workitem_json_end | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
 
     # getting comments if enabled
     if($gh_add_ado_comments -eq $true) {
@@ -129,15 +136,15 @@ ForEach($workitem in $query) {
         if($response.count -gt 0) {
             $ado_comments_details=""
             $ado_original_workitem_json_beginning="`n`n<details><summary>Work Item Comments ($($response.count))</summary><p>" + "`n`n"
-            $ado_original_workitem_json_beginning | Add-Content -Path ./temp_comment_body.txt
+            $ado_original_workitem_json_beginning | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
             ForEach($comment in $response.comments) {
                 $ado_comments_details= "| Created date | Created by | JSON URL |`n|---|---|---|`n"
                 $ado_comments_details+="| $($comment.createdDate) | $($comment.createdBy.displayName) | [URL]($($comment.url)) |`n`n"
                 $ado_comments_details+="**Comment text**: $($comment.text)`n`n-----------`n`n"
-                $ado_comments_details | Add-Content -Path ./temp_comment_body.txt
+                $ado_comments_details | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
             }
             $ado_original_workitem_json_end="`n" + "`n</p></details>"
-            $ado_original_workitem_json_end | Add-Content -Path ./temp_comment_body.txt
+            $ado_original_workitem_json_end | Add-Content -Path ./temp_comment_body.txt -Encoding ASCII;
         }
     }
     
@@ -146,7 +153,14 @@ ForEach($workitem in $query) {
 
     # create the issue
     $issue_url=gh issue create --body-file ./temp_issue_body.txt --repo "$gh_org/$gh_repo" --title "$title" --label $work_item_type
-    write-host "issue created: $issue_url"
+    
+    if (![string]::IsNullOrEmpty($issue_url.Trim())) {
+        Write-Host "  Issue created: $issue_url";
+        $count++;
+    }
+    else {
+        throw "Issue creation failed.";
+    }
     
     # update assigned to in GitHub if the option is set - tries to use ado email to map to github username
     if ($gh_update_assigned_to -eq $true -and $ado_assigned_to_unique_name -ne "") {
@@ -163,6 +177,10 @@ ForEach($workitem in $query) {
     Remove-Item -Path ./temp_comment_body.txt -ErrorAction SilentlyContinue
     Remove-Item -Path ./temp_issue_body.txt -ErrorAction SilentlyContinue
 
+    # Add the tag "copied-to-github" plus a comment to the work item
+    $discussion = "This work item was copied to github as issue <a href=`"$issue_url`">$issue_url</a>";
+    az boards work-item update --id "$workitemId" --fields "System.Tags=copied-to-github; $workitemTags" --discussion "$discussion" | Out-Null;
+
     # close out the issue if it's closed on the Azure Devops side
     $ado_closure_states = "Done","Closed","Resolved","Removed"
     if ($ado_closure_states.Contains($details.fields.{System.State})) {
@@ -170,3 +188,4 @@ ForEach($workitem in $query) {
     }
     
 }
+Write-Host "Total items copied: $count"

--- a/ado_workitems_to_github_issues.ps1
+++ b/ado_workitems_to_github_issues.ps1
@@ -10,7 +10,7 @@
 #      - You can modify the WIQL if you want to use a different way to migrate work items, such as [TAG] = "migrate"
 
 # How to run:
-# ./ado_workitems_to_github_issues.ps1 -ado_pat "xxx" -ado_org "jjohanning0798" -ado_project "PartsUnlimited" -ado_area_path "PartsUnlimited\migrate" -gh_pat "xxx" -gh_org "joshjohanning-org" -gh_repo "migrate-ado-workitems" -gh_update_assigned_to $true -gh_assigned_to_user_suffix "_corp" -gh_migrate_ado_comments $true -gh_migrate_closed_workitems $false -ado_production_run $true
+# ./ado_workitems_to_github_issues.ps1 -ado_pat "xxx" -ado_org "jjohanning0798" -ado_project "PartsUnlimited" -ado_area_path "PartsUnlimited\migrate" -ado_migrate_closed_workitems $false -ado_production_run $true -gh_pat "xxx" -gh_org "joshjohanning-org" -gh_repo "migrate-ado-workitems" -gh_update_assigned_to $true -gh_assigned_to_user_suffix "_corp" -gh_migrate_ado_comments $true
 
 #
 # Things it migrates:

--- a/ado_workitems_to_github_issues.ps1
+++ b/ado_workitems_to_github_issues.ps1
@@ -166,13 +166,13 @@ ForEach($workitem in $query) {
     if ($gh_update_assigned_to -eq $true -and $ado_assigned_to_unique_name -ne "") {
         $gh_assignee=$ado_assigned_to_unique_name.Split("@")[0]
         $gh_assignee=$gh_assignee.Replace(".", "-") + $gh_assigned_to_user_suffix
-        write-host "trying to assign to: $gh_assignee"
+        write-host "  trying to assign to: $gh_assignee"
         $assigned=gh issue edit $issue_url --add-assignee "$gh_assignee"
     }
 
     # add the comment
     $comment_url=gh issue comment $issue_url --body-file ./temp_comment_body.txt
-    write-host "comment created: $comment_url"
+    write-host "  comment created: $comment_url"
 
     Remove-Item -Path ./temp_comment_body.txt -ErrorAction SilentlyContinue
     Remove-Item -Path ./temp_issue_body.txt -ErrorAction SilentlyContinue

--- a/ado_workitems_to_github_issues.ps1
+++ b/ado_workitems_to_github_issues.ps1
@@ -52,7 +52,7 @@ $env:GH_TOKEN = $gh_pat;
 
 az devops configure --defaults organization="https://dev.azure.com/$ado_org" project="$ado_project"
 
-$wiql = "select [ID], [Title], [System.Tags] from workitems where [State] <> 'Done' and [State] <> 'Closed' and [State] <> 'Resolved' and [State] <> 'Removed' and [System.AreaPath] UNDER '$ado_area_path' and [System.Title] Contains 'CodeQL' and not [System.Tags] Contains 'copied-to-github' order by [ID]";
+$wiql = "select [ID], [Title], [System.Tags] from workitems where [State] <> 'Done' and [State] <> 'Closed' and [State] <> 'Resolved' and [State] <> 'Removed' and [System.AreaPath] UNDER '$ado_area_path' and not [System.Tags] Contains 'copied-to-github' order by [ID]";
 
 $query=az boards query --wiql $wiql | ConvertFrom-Json
 


### PR DESCRIPTION
### Changes
- Create a tag on the ADO work item saying it's been copied to GitHub
- Create a comment on the ADO work item giving a link to the GitHub item it was coped to
- Improve authentication using environment vars instead of logins. Logins want to be interactive and can be buggy
- Change WI query to 
  - Exclude work items tagged as already copied
  - Exclude work items with state "Done", etc.
- Report total items copied
- Add `-Encoding ASCII` to file writes. Default is Unicode. Our GitHub repos are not set up for Unicode text in issue and comment bodies.