### PR TITLE
chore: rename secret PRIVATE_KEY to APP_PRIVATE_KEY

### DIFF
--- a/.github/workflows/migrate-work-items.yml
+++ b/.github/workflows/migrate-work-items.yml
@@ -66,7 +66,7 @@ jobs:
       #   id: app-token
       #   with:
       #     client-id: 179484 # work-item-migrator
-      #     private-key: ${{ secrets.PRIVATE_KEY }}
+      #     private-key: ${{ secrets.APP_PRIVATE_KEY }}
       #     owner: ${{ github.repository_owner }}
       
       - name: run migration


### PR DESCRIPTION
## Summary

Renames secret references from `secrets.PRIVATE_KEY` to `secrets.APP_PRIVATE_KEY` for consistency across all repos.

### ⚠️ Before Merging
1. Create a new secret `APP_PRIVATE_KEY` with the same value as `PRIVATE_KEY`
2. Then merge this PR
3. Delete the old `PRIVATE_KEY` secret